### PR TITLE
fix(ci): 修复 release-please workflow 配置

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,26 +13,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
-        with:
-          # 发布类型：Node.js 项目
-          release-type: node
-          # 包名称
-          package-name: claude-config-manager
-          # 自动生成 CHANGELOG
-          changelog-types: '[
-            {"type":"feat","section":"✨ Features","hidden":false},
-            {"type":"fix","section":"🐛 Bug Fixes","hidden":false},
-            {"type":"docs","section":"📚 Documentation","hidden":false},
-            {"type":"style","section":"💎 Styles","hidden":false},
-            {"type":"refactor","section":"♻️ Code Refactoring","hidden":false},
-            {"type":"perf","section":"⚡ Performance Improvements","hidden":false},
-            {"type":"test","section":"✅ Tests","hidden":false},
-            {"type":"build","section":"🔨 Build System","hidden":false},
-            {"type":"ci","section":"👷 CI/CD","hidden":false},
-            {"type":"chore","section":"🔧 Chores","hidden":true}
-          ]'
 
       # 当 Release 被创建时，自动发布到 npm（可选）
       - name: Checkout code

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,18 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "changelog-types": [
+        {"type":"feat","section":"✨ Features","hidden":false},
+        {"type":"fix","section":"🐛 Bug Fixes","hidden":false},
+        {"type":"docs","section":"📚 Documentation","hidden":false},
+        {"type":"style","section":"💎 Styles","hidden":false},
+        {"type":"refactor","section":"♻️ Code Refactoring","hidden":false},
+        {"type":"perf","section":"⚡ Performance Improvements","hidden":false},
+        {"type":"test","section":"✅ Tests","hidden":false},
+        {"type":"build","section":"🔨 Build System","hidden":false},
+        {"type":"ci","section":"👷 CI/CD","hidden":false},
+        {"type":"chore","section":"🔧 Chores","hidden":true}
+      ],
       "extra-files": [
         "package.json",
         "package-lock.json"


### PR DESCRIPTION
## 问题描述

首次运行 release-please workflow 失败，原因：
1. 使用了过时的 action 名称：`google-github-actions/release-please-action@v4`
2. workflow 中使用了 v4 不支持的参数
3. GitHub Actions 报错无法创建 PR

## 修复内容

### 1. 更新 Action 名称
```yaml
# 修复前
- uses: google-github-actions/release-please-action@v4

# 修复后
- uses: googleapis/release-please-action@v4
```

### 2. 简化 Workflow 配置
移除 workflow 中不支持的参数：
- ❌ `release-type` 
- ❌ `package-name`
- ❌ `changelog-types`

这些配置通过配置文件管理更好。

### 3. 完善配置文件
在 `release-please-config.json` 中添加 `changelog-types` 配置：
```json
{
  "changelog-types": [
    {"type":"feat","section":"✨ Features","hidden":false},
    {"type":"fix","section":"🐛 Bug Fixes","hidden":false},
    ...
  ]
}
```

## 工作流程说明

符合业界最佳实践：

```
日常开发
  ↓
自动创建/更新 Release PR（累积变更）
  ↓
人工审核并决定何时发布
  ↓
合并 Release PR → 自动创建 Tag + GitHub Release
```

### 特点
- ✅ 自动化：自动分析提交、生成 CHANGELOG
- ✅ 可控：团队决定发布时机
- ✅ 透明：Release PR 可审核和修改
- ✅ 灵活：支持按需发布或定期发布

## 测试

合并此 PR 后，release-please 将：
1. 分析历史提交（`feat: initial commit` 和 `ci:` 提交）
2. 自动创建 Release PR（v0.1.0）
3. 等待人工审核合并

## 参考文档

- [Release Please v4 文档](https://github.com/googleapis/release-please)
- [配置文件 Schema](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md)
- [最佳实践](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

## 检查清单

- [x] 修复 workflow 配置错误
- [x] 更新配置文件格式
- [x] 测试 workflow 语法正确
- [x] 遵循最佳实践
- [x] 更新相关文档