### PR TITLE
chore: 配置 npm 包发布

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,9 +35,12 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         run: npm run build
 
-      # 可选：发布到 npm
-      # - name: Publish to npm
-      #   if: ${{ steps.release.outputs.release_created }}
-      #   run: npm publish
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # 发布到 npm
+      - name: Setup .npmrc
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+      - name: Publish to npm
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm publish --access public

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,55 @@
+# 源代码文件
+src/
+*.ts
+!*.d.ts
+
+# 配置文件
+tsconfig.json
+.prettierrc
+.eslintrc*
+.editorconfig
+
+# 开发文档
+AGENTS.md
+QUICKSTART.md
+RELEASE.md
+
+# 测试文件
+tests/
+test/
+*.test.js
+*.spec.js
+
+# Git 相关
+.git/
+.gitignore
+.gitattributes
+
+# CI/CD
+.github/
+.travis.yml
+.circleci/
+
+# IDE 配置
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# 系统文件
+.DS_Store
+Thumbs.db
+
+# 依赖
+node_modules/
+
+# 日志
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# 临时文件
+*.tmp
+.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,3 +177,131 @@ Claude Code 的配置文件通常位于：
 - 函数保持简洁，单个函数不超过 50 行
 - 避免使用 any 类型，必要时使用 unknown
 - 所有异步操作使用 async/await
+
+## 版本发布规范
+
+### 11. Git 工作流
+
+#### 11.1 分支管理
+- **main 分支**：主分支，受保护，只能通过 PR 合并
+- **feature/***: 功能开发分支
+- **fix/***: 问题修复分支
+- **chore/***: 配置和工具相关的修改分支
+
+#### 11.2 提交规范
+遵循 Conventional Commits 规范：
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**常用 type：**
+- `feat`: 新功能
+- `fix`: 修复 bug
+- `docs`: 文档更新
+- `style`: 代码格式调整（不影响功能）
+- `refactor`: 重构代码
+- `perf`: 性能优化
+- `test`: 测试相关
+- `build`: 构建系统或外部依赖变更
+- `ci`: CI 配置变更
+- `chore`: 其他不修改源代码的更改
+
+**示例：**
+```bash
+feat(api): 添加配置导出功能
+fix(config): 修复配置切换时的路径错误
+chore(npm): 配置 npm 包发布
+```
+
+#### 11.3 代码提交流程
+
+**重要原则：永远不要直接推送到 main 分支！**
+
+1. **创建功能分支**
+   ```bash
+   git checkout -b feature/your-feature-name
+   # 或
+   git checkout -b fix/bug-description
+   # 或
+   git checkout -b chore/task-description
+   ```
+
+2. **开发并提交代码**
+   ```bash
+   git add .
+   git commit -m "feat: 功能描述"
+   ```
+
+3. **推送到远程分支**
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+4. **创建 Pull Request**
+   - 在 GitHub 上创建 PR
+   - 填写清晰的 PR 描述
+   - 等待 CI 检查通过
+   - 代码审查通过后合并到 main
+
+### 12. npm 发布流程
+
+本项目使用 **release-please** 自动化版本管理和发布。
+
+#### 12.1 自动发布流程
+
+1. **提交符合规范的 commit 到 main 分支**
+   - 通过 PR 合并到 main
+   - release-please 会分析 commit 消息
+
+2. **release-please 自动创建 Release PR**
+   - 自动更新版本号（遵循语义化版本）
+   - 自动生成 CHANGELOG.md
+   - PR 标题格式：`chore(main): release x.x.x`
+
+3. **合并 Release PR 触发发布**
+   - 自动构建项目（`npm run build`）
+   - 自动发布到 npm（`npm publish`）
+   - 自动创建 GitHub Release
+
+#### 12.2 版本号规则
+
+遵循语义化版本（Semantic Versioning）：`MAJOR.MINOR.PATCH`
+
+- `feat`: 增加 MINOR 版本（例如：1.0.0 → 1.1.0）
+- `fix`: 增加 PATCH 版本（例如：1.0.0 → 1.0.1）
+- `BREAKING CHANGE`: 增加 MAJOR 版本（例如：1.0.0 → 2.0.0）
+
+**触发 BREAKING CHANGE 的方式：**
+```bash
+git commit -m "feat!: 重构 API 接口"
+# 或
+git commit -m "feat: 重构 API 接口
+
+BREAKING CHANGE: API 接口签名已更改"
+```
+
+#### 12.3 发布前检查清单
+
+- [ ] 代码已通过所有测试
+- [ ] TypeScript 编译无错误
+- [ ] 更新了相关文档
+- [ ] commit 消息符合规范
+- [ ] 通过功能分支 PR 合并到 main
+- [ ] 确保 npm token 已配置（GitHub Secrets: `NPM_TOKEN`）
+
+#### 12.4 手动发布（仅限紧急情况）
+
+如需手动发布，执行：
+```bash
+npm run build
+npm version patch  # 或 minor, major
+npm publish --access public
+git push --tags
+```
+
+⚠️ **注意：优先使用自动发布流程，手动发布仅用于紧急情况！**

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 yangtuooc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -6,11 +6,17 @@
   "bin": {
     "ccm": "./dist/cli.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/cli.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "claude",
@@ -18,10 +24,24 @@
     "api",
     "config",
     "manager",
-    "cli"
+    "cli",
+    "configuration",
+    "api-management",
+    "anthropic"
   ],
-  "author": "",
+  "author": "yangtuooc",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yangtuooc/claude-config-manager.git"
+  },
+  "bugs": {
+    "url": "https://github.com/yangtuooc/claude-config-manager/issues"
+  },
+  "homepage": "https://github.com/yangtuooc/claude-config-manager#readme",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "devDependencies": {
     "@types/inquirer": "^9.0.9",
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## 概述

配置项目的 npm 包发布流程，实现自动化发布到 npmjs.com。

## 主要变更

### 📦 npm 发布配置
- ✅ 更新 `package.json` 添加发布所需字段
  - `files`: 只发布 `dist/`、`README.md`、`LICENSE`
  - `repository`、`bugs`、`homepage`: 仓库信息
  - `engines`: 要求 Node.js >= 16.0.0
  - `prepublishOnly`: 发布前自动构建
  - `author`: yangtuooc
  - 优化 `keywords`: 增加搜索可见性

### 📝 发布相关文件
- ✅ 创建 `.npmignore`: 排除源代码和开发文件，只发布编译后的内容
- ✅ 创建 `LICENSE`: MIT License

### 🔄 自动化发布
- ✅ 更新 GitHub Actions workflow (`.github/workflows/release-please.yml`)
  - 启用自动发布到 npm
  - 配置 npm token 认证
  - 使用 `--access public` 确保公开发布

### 📚 文档更新
- ✅ 更新 `AGENTS.md` 添加完整的版本发布规范
  - Git 工作流和分支管理
  - Conventional Commits 提交规范
  - 代码提交流程（强调不直接推送到 main）
  - npm 自动发布流程说明
  - 语义化版本规则

## 发布流程

合并此 PR 后，发布流程如下：

1. **release-please 自动创建 Release PR**
   - 分析 commit 消息
   - 更新版本号
   - 生成 CHANGELOG

2. **合并 Release PR 触发自动发布**
   - ✅ 编译项目
   - ✅ 发布到 npm
   - ✅ 创建 GitHub Release

3. **用户可通过 npm 安装**
   ```bash
   npm install -g claude-config-manager
   ```

## 验证

- ✅ 本地构建成功：`npm run build`
- ✅ 打包验证：`npm pack --dry-run`
- ✅ 包大小：18.6 kB（压缩后）
- ✅ 包含 43 个文件

## 依赖

需要确保 GitHub Secrets 中已配置 `NPM_TOKEN`（已由用户配置完成）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>