### PR TITLE
fix(ci): 修复 lint job 中版本文件生成问题

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate version file
+        run: npm run prebuild
+
       - name: Check TypeScript types
         run: npx tsc --noEmit


### PR DESCRIPTION
## 问题描述

CI lint job 执行失败，错误信息：
```
src/cli.ts(5,25): error TS2307: Cannot find module './version' or its corresponding type declarations.
```

## 根本原因

1. `src/version.ts` 是自动生成的文件（不在 git 中）
2. CI lint job 没有执行 `prebuild` 脚本，所以没有生成版本文件
3. `src/cli.ts` 导入 `./version`，导致 TypeScript 编译检查失败

## 修复方案

在 CI lint job 中添加 'Generate version file' 步骤，在类型检查前先执行 `npm run prebuild` 生成版本文件。

## 变更内容

- 修改 `.github/workflows/ci.yml`
- 在 lint job 中添加 `npm run prebuild` 步骤

## 验证

修复后 CI lint job 应该能够正常执行 TypeScript 类型检查。