### PR TITLE
feat: 实现 update 命令，支持自动检测和安装最新版本

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { addCommand, listTemplates } from './commands/add';
 import { listCommand, showCommand } from './commands/list';
 import { switchCommand } from './commands/switch';
 import { removeCommand } from './commands/remove';
+import { updateCommand } from './commands/update';
 
 const program = new Command();
 
@@ -128,6 +129,18 @@ program
       console.log('');
     } catch (error) {
       console.log(chalk.red('获取当前配置失败'));
+      process.exit(1);
+    }
+  });
+
+// update 命令 - 检查并安装更新
+program
+  .command('update')
+  .description('检查并安装最新版本')
+  .action(async () => {
+    try {
+      await updateCommand();
+    } catch (error) {
       process.exit(1);
     }
   });

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,65 @@
+import chalk from 'chalk';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { getLatestVersion, compareVersions } from '../utils/version-checker';
+import { VERSION } from '../version';
+
+const execAsync = promisify(exec);
+
+/**
+ * 更新命令
+ * 检查并安装最新版本
+ */
+export async function updateCommand(): Promise<void> {
+  try {
+    const packageName = 'claude-config-manager';
+
+    console.log(chalk.cyan('检查更新...'));
+    console.log(chalk.gray(`当前版本: ${VERSION}`));
+
+    // 获取最新版本
+    const latestVersion = await getLatestVersion(packageName);
+
+    if (!latestVersion) {
+      console.log(chalk.yellow('无法获取最新版本信息，请检查网络连接'));
+      return;
+    }
+
+    console.log(chalk.gray(`最新版本: ${latestVersion}`));
+    console.log('');
+
+    // 比较版本
+    const compareResult = compareVersions(VERSION, latestVersion);
+
+    if (compareResult >= 0) {
+      console.log(chalk.green('✓ 已是最新版本，无需更新'));
+      return;
+    }
+
+    // 有新版本，开始安装
+    console.log(chalk.cyan(`发现新版本，开始安装...`));
+    console.log('');
+
+    try {
+      await execAsync(`npm install -g ${packageName}@latest`);
+      console.log('');
+      console.log(chalk.green(`✓ 更新成功，已安装版本 ${latestVersion}`));
+      console.log(chalk.gray('请在新终端窗口中使用新版本'));
+    } catch (error) {
+      console.log('');
+      console.log(chalk.red('✗ 安装失败'));
+      if (error instanceof Error) {
+        console.log(chalk.gray(`错误: ${error.message}`));
+      }
+      console.log(chalk.gray(`请手动运行: npm install -g ${packageName}@latest`));
+      throw error;
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      console.log(chalk.red(`✗ ${error.message}`));
+    } else {
+      console.log(chalk.red('检查更新失败'));
+    }
+    throw error;
+  }
+}

--- a/src/utils/version-checker.ts
+++ b/src/utils/version-checker.ts
@@ -1,0 +1,59 @@
+/**
+ * 版本检查和更新工具
+ */
+
+/**
+ * 从 npm registry 获取最新版本
+ */
+export async function getLatestVersion(packageName: string): Promise<string | null> {
+  try {
+    const response = await fetch(`https://registry.npmjs.org/${packageName}`);
+    if (!response.ok) {
+      return null;
+    }
+    const data = await response.json() as { 'dist-tags': { latest: string } };
+    return data['dist-tags'].latest;
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * 比较版本号
+ * 返回值：
+ *   > 0: version1 > version2
+ *   = 0: version1 = version2
+ *   < 0: version1 < version2
+ */
+export function compareVersions(version1: string, version2: string): number {
+  const v1Parts = version1.split('.').map(x => parseInt(x, 10));
+  const v2Parts = version2.split('.').map(x => parseInt(x, 10));
+
+  for (let i = 0; i < 3; i++) {
+    const v1 = v1Parts[i] || 0;
+    const v2 = v2Parts[i] || 0;
+
+    if (v1 > v2) return 1;
+    if (v1 < v2) return -1;
+  }
+
+  return 0;
+}
+
+/**
+ * 检查是否有更新可用
+ */
+export async function hasUpdateAvailable(currentVersion: string, packageName: string): Promise<{
+  hasUpdate: boolean;
+  latestVersion: string | null;
+}> {
+  const latestVersion = await getLatestVersion(packageName);
+
+  if (!latestVersion) {
+    return { hasUpdate: false, latestVersion: null };
+  }
+
+  const hasUpdate = compareVersions(currentVersion, latestVersion) < 0;
+
+  return { hasUpdate, latestVersion };
+}


### PR DESCRIPTION
## 功能简介

实现 Issue #10：添加 `ccm update` 命令，支持检查 npm registry 最新版本并自动安装。

## 核心功能

### 1. 版本检查工具（src/utils/version-checker.ts）
- `getLatestVersion(packageName)` - 从 npm registry 获取最新版本
- `compareVersions(v1, v2)` - 语义化版本号比较
- `hasUpdateAvailable(currentVersion, packageName)` - 检查是否有可用更新

### 2. Update 命令（src/commands/update.ts）
- 检查 npm registry 获取最新版本
- 对比当前版本与最新版本
- 如果有新版本，自动执行 `npm install -g` 安装
- 清晰的命令行提示和错误处理

### 3. CLI 集成
在 `src/cli.ts` 中添加 update 命令

## 使用示例

### 已是最新版本
```bash
$ ccm update
检查更新...
当前版本: 0.1.2
最新版本: 0.1.2

✓ 已是最新版本，无需更新
```

### 有新版本可用
```bash
$ ccm update
检查更新...
当前版本: 0.1.2
最新版本: 0.2.0

发现新版本，开始安装...

✓ 更新成功，已安装版本 0.2.0
请在新终端窗口中使用新版本
```

## 技术细节

- ✅ 使用 fetch API 获取 npm registry 数据
- ✅ 使用 child_process.exec 执行 npm install 命令
- ✅ 完整的错误处理和用户反馈
- ✅ 无外部依赖（不需要 semver 包）

## 验证

✅ 构建成功，无 TypeScript 错误
✅ `ccm update` 命令正常工作
✅ 版本比较逻辑通过测试
✅ npm registry API 调用成功