### PR TITLE
feat: 支持同一站点维护多个 API Key

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { listCommand, showCommand } from './commands/list';
 import { switchCommand } from './commands/switch';
 import { removeCommand } from './commands/remove';
 import { updateCommand } from './commands/update';
+import { keyAddCommand, keyListCommand, keySwitchCommand, keyRemoveCommand } from './commands/key';
 
 const program = new Command();
 
@@ -129,6 +130,65 @@ program
       console.log('');
     } catch (error) {
       console.log(chalk.red('获取当前配置失败'));
+      process.exit(1);
+    }
+  });
+
+// key 命令 - 管理配置的多个 API Keys
+const keyCommand = program.command('key').description('管理配置的 API Keys');
+
+// key add 子命令
+keyCommand
+  .command('add [config-name]')
+  .description('为配置添加新的 API Key')
+  .option('-k, --api-key <key>', 'API Key')
+  .option('-a, --alias <alias>', 'Key 别名')
+  .action(async (configName, options) => {
+    try {
+      const manager = await createConfigManager();
+      await keyAddCommand(manager, configName, options);
+    } catch (error) {
+      process.exit(1);
+    }
+  });
+
+// key list 子命令
+keyCommand
+  .command('list [config-name]')
+  .alias('ls')
+  .description('列出配置的所有 API Keys')
+  .action(async (configName) => {
+    try {
+      const manager = await createConfigManager();
+      await keyListCommand(manager, configName);
+    } catch (error) {
+      process.exit(1);
+    }
+  });
+
+// key switch 子命令
+keyCommand
+  .command('switch [config-name] [key-id-or-alias]')
+  .description('切换配置的活动 API Key')
+  .action(async (configName, keyIdOrAlias) => {
+    try {
+      const manager = await createConfigManager();
+      await keySwitchCommand(manager, configName, keyIdOrAlias);
+    } catch (error) {
+      process.exit(1);
+    }
+  });
+
+// key remove 子命令
+keyCommand
+  .command('remove [config-name] [key-id-or-alias]')
+  .alias('rm')
+  .description('删除配置的 API Key')
+  .action(async (configName, keyIdOrAlias) => {
+    try {
+      const manager = await createConfigManager();
+      await keyRemoveCommand(manager, configName, keyIdOrAlias);
+    } catch (error) {
       process.exit(1);
     }
   });

--- a/src/commands/key.ts
+++ b/src/commands/key.ts
@@ -1,0 +1,359 @@
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import Table from 'cli-table3';
+import { ConfigManager } from '../config-manager';
+import { maskApiKey, getActiveKey } from '../utils/config-helpers';
+
+/**
+ * key add 命令 - 添加新的 API Key
+ */
+export async function keyAddCommand(
+  manager: ConfigManager,
+  configName?: string,
+  options: {
+    apiKey?: string;
+    alias?: string;
+  } = {}
+): Promise<void> {
+  try {
+    // 如果没有提供配置名称，交互式选择
+    if (!configName) {
+      const configs = manager.getAllConfigs();
+      if (configs.length === 0) {
+        console.log(chalk.yellow('还没有任何配置'));
+        console.log(chalk.gray('使用 "ccm add" 添加第一个配置'));
+        return;
+      }
+
+      const { selected } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'selected',
+          message: '选择要添加 Key 的配置:',
+          choices: configs.map(c => ({
+            name: `${c.name} (${c.baseUrl})`,
+            value: c.name
+          }))
+        }
+      ]);
+      configName = selected;
+    }
+
+    // 检查配置是否存在
+    const config = manager.getConfig(configName!);
+    if (!config) {
+      console.log(chalk.red(`配置 "${configName}" 不存在`));
+      return;
+    }
+
+    let { apiKey, alias } = options;
+
+    // 交互式输入缺失字段
+    if (!apiKey) {
+      const answers = await inquirer.prompt([
+        {
+          type: 'password',
+          name: 'apiKey',
+          message: 'API Key:',
+          mask: '*',
+          validate: (input: string) => {
+            if (!input.trim()) {
+              return 'API Key 不能为空';
+            }
+            return true;
+          }
+        }
+      ]);
+      apiKey = answers.apiKey;
+    }
+
+    if (!alias) {
+      const answers = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'alias',
+          message: '别名 (可选):',
+        }
+      ]);
+      alias = answers.alias || undefined;
+    }
+
+    // 添加 Key
+    await manager.addKey(configName!, apiKey!, alias);
+
+    console.log(chalk.green(`✓ 已为配置 "${configName}" 添加新的 API Key`));
+    if (alias) {
+      console.log(chalk.gray(`  别名: ${alias}`));
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      console.log(chalk.red(`✗ ${error.message}`));
+    } else {
+      console.log(chalk.red('添加 Key 失败'));
+    }
+    throw error;
+  }
+}
+
+/**
+ * key list 命令 - 列出配置的所有 Keys
+ */
+export async function keyListCommand(
+  manager: ConfigManager,
+  configName?: string
+): Promise<void> {
+  try {
+    // 如果没有提供配置名称，交互式选择
+    if (!configName) {
+      const configs = manager.getAllConfigs();
+      if (configs.length === 0) {
+        console.log(chalk.yellow('还没有任何配置'));
+        console.log(chalk.gray('使用 "ccm add" 添加第一个配置'));
+        return;
+      }
+
+      const { selected } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'selected',
+          message: '选择要查看 Keys 的配置:',
+          choices: configs.map(c => ({
+            name: `${c.name} (${c.baseUrl})`,
+            value: c.name
+          }))
+        }
+      ]);
+      configName = selected;
+    }
+
+    const config = manager.getConfig(configName!);
+    if (!config) {
+      console.log(chalk.red(`配置 "${configName}" 不存在`));
+      return;
+    }
+
+    const keys = manager.listKeys(configName!);
+
+    if (keys.length === 0) {
+      console.log(chalk.yellow(`配置 "${configName}" 没有 API Key`));
+      return;
+    }
+
+    const activeKey = getActiveKey(config);
+
+    console.log(chalk.bold(`\n${configName} 的 API Keys:\n`));
+
+    const table = new Table({
+      head: [
+        chalk.cyan('别名'),
+        chalk.cyan('API Key'),
+        chalk.cyan('状态'),
+        chalk.cyan('最后使用')
+      ],
+      colWidths: [20, 25, 12, 20]
+    });
+
+    keys.forEach(key => {
+      const isActive = activeKey?.id === key.id;
+      const status = isActive ? chalk.green('✓ 活动') : (key.isDefault ? chalk.blue('默认') : '');
+      const alias = key.alias || chalk.gray('(无)');
+      const lastUsed = key.lastUsed
+        ? new Date(key.lastUsed).toLocaleString('zh-CN')
+        : chalk.gray('-');
+
+      table.push([
+        alias,
+        maskApiKey(key.apiKey),
+        status,
+        lastUsed
+      ]);
+    });
+
+    console.log(table.toString());
+    console.log(chalk.gray(`\n共 ${keys.length} 个 Key`));
+    console.log('');
+  } catch (error) {
+    if (error instanceof Error) {
+      console.log(chalk.red(`✗ ${error.message}`));
+    } else {
+      console.log(chalk.red('列出 Keys 失败'));
+    }
+    throw error;
+  }
+}
+
+/**
+ * key switch 命令 - 切换活动 Key
+ */
+export async function keySwitchCommand(
+  manager: ConfigManager,
+  configName?: string,
+  keyIdOrAlias?: string
+): Promise<void> {
+  try {
+    // 如果没有提供配置名称，交互式选择
+    if (!configName) {
+      const configs = manager.getAllConfigs();
+      if (configs.length === 0) {
+        console.log(chalk.yellow('还没有任何配置'));
+        console.log(chalk.gray('使用 "ccm add" 添加第一个配置'));
+        return;
+      }
+
+      const { selected } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'selected',
+          message: '选择要切换 Key 的配置:',
+          choices: configs.map(c => ({
+            name: `${c.name} (${c.baseUrl})`,
+            value: c.name
+          }))
+        }
+      ]);
+      configName = selected;
+    }
+
+    const config = manager.getConfig(configName!);
+    if (!config) {
+      console.log(chalk.red(`配置 "${configName}" 不存在`));
+      return;
+    }
+
+    // 如果没有指定 keyIdOrAlias，交互式选择
+    if (!keyIdOrAlias) {
+      const keys = manager.listKeys(configName!);
+      if (keys.length === 0) {
+        console.log(chalk.yellow('没有可用的 Key'));
+        return;
+      }
+
+      const activeKey = getActiveKey(config);
+
+      const { selected } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'selected',
+          message: '选择要切换到的 Key:',
+          choices: keys.map(k => ({
+            name: `${k.alias || maskApiKey(k.apiKey)} ${activeKey?.id === k.id ? chalk.green('(当前)') : ''}`,
+            value: k.id
+          }))
+        }
+      ]);
+      keyIdOrAlias = selected;
+    }
+
+    await manager.switchKey(configName!, keyIdOrAlias!);
+    console.log(chalk.green(`✓ 已切换配置 "${configName}" 的活动 Key 到: ${keyIdOrAlias}`));
+
+    // 询问是否立即应用
+    const { apply } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'apply',
+        message: '是否立即应用到 Claude Code?',
+        default: true
+      }
+    ]);
+
+    if (apply) {
+      await manager.applyToClaudeCode(configName!);
+      console.log(chalk.green(`✓ 已应用到 Claude Code`));
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      console.log(chalk.red(`✗ ${error.message}`));
+    } else {
+      console.log(chalk.red('切换 Key 失败'));
+    }
+    throw error;
+  }
+}
+
+/**
+ * key remove 命令 - 删除 Key
+ */
+export async function keyRemoveCommand(
+  manager: ConfigManager,
+  configName?: string,
+  keyIdOrAlias?: string
+): Promise<void> {
+  try {
+    // 如果没有提供配置名称，交互式选择
+    if (!configName) {
+      const configs = manager.getAllConfigs();
+      if (configs.length === 0) {
+        console.log(chalk.yellow('还没有任何配置'));
+        console.log(chalk.gray('使用 "ccm add" 添加第一个配置'));
+        return;
+      }
+
+      const { selected } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'selected',
+          message: '选择要删除 Key 的配置:',
+          choices: configs.map(c => ({
+            name: `${c.name} (${c.baseUrl})`,
+            value: c.name
+          }))
+        }
+      ]);
+      configName = selected;
+    }
+
+    const config = manager.getConfig(configName!);
+    if (!config) {
+      console.log(chalk.red(`配置 "${configName}" 不存在`));
+      return;
+    }
+
+    // 如果没有指定 keyIdOrAlias，交互式选择
+    if (!keyIdOrAlias) {
+      const keys = manager.listKeys(configName!);
+      if (keys.length === 0) {
+        console.log(chalk.yellow('没有可删除的 Key'));
+        return;
+      }
+
+      const { selected } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'selected',
+          message: '选择要删除的 Key:',
+          choices: keys.map(k => ({
+            name: `${k.alias || maskApiKey(k.apiKey)} ${k.isDefault ? chalk.blue('(默认)') : ''}`,
+            value: k.id
+          }))
+        }
+      ]);
+      keyIdOrAlias = selected;
+    }
+
+    // 确认删除
+    const { confirm } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'confirm',
+        message: `确认删除 Key "${keyIdOrAlias}"?`,
+        default: false
+      }
+    ]);
+
+    if (!confirm) {
+      console.log(chalk.yellow('已取消'));
+      return;
+    }
+
+    await manager.removeKey(configName!, keyIdOrAlias!);
+    console.log(chalk.green(`✓ 已删除 Key "${keyIdOrAlias}"`));
+  } catch (error) {
+    if (error instanceof Error) {
+      console.log(chalk.red(`✗ ${error.message}`));
+    } else {
+      console.log(chalk.red('删除 Key 失败'));
+    }
+    throw error;
+  }
+}

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import Table from 'cli-table3';
 import { ConfigManager } from '../config-manager';
+import { getActiveApiKey, maskApiKey } from '../utils/config-helpers';
 
 /**
  * 列出所有配置命令
@@ -89,26 +90,21 @@ export async function showCommand(manager: ConfigManager, name: string): Promise
   const activeConfig = await manager.getActiveConfig();
   const isActive = activeConfig?.name === name;
 
+  // 获取活动 API Key
+  const apiKey = getActiveApiKey(config);
+  const keysCount = config.keys.length;
+
   console.log('\n' + chalk.bold('配置详情:') + '\n');
   console.log(chalk.cyan('名称:       ') + config.name);
   console.log(chalk.cyan('类型:       ') + formatType(config.type));
   console.log(chalk.cyan('Base URL:   ') + config.baseUrl);
-  console.log(chalk.cyan('API Key:    ') + maskApiKey(config.apiKey));
+  console.log(chalk.cyan('API Keys:   ') + `${keysCount} 个`);
+  if (apiKey) {
+    console.log(chalk.cyan('活动 Key:   ') + maskApiKey(apiKey));
+  }
   console.log(chalk.cyan('描述:       ') + (config.description || '-'));
   console.log(chalk.cyan('状态:       ') + (isActive ? chalk.green('活动') : chalk.gray('未激活')));
   console.log(chalk.gray('创建时间:   ') + new Date(config.createdAt).toLocaleString('zh-CN'));
   console.log(chalk.gray('更新时间:   ') + new Date(config.updatedAt).toLocaleString('zh-CN'));
   console.log('');
-}
-
-/**
- * 隐藏 API Key 中间部分
- */
-function maskApiKey(apiKey: string): string {
-  if (apiKey.length <= 10) {
-    return '*'.repeat(apiKey.length);
-  }
-  const start = apiKey.substring(0, 4);
-  const end = apiKey.substring(apiKey.length - 4);
-  return `${start}${'*'.repeat(apiKey.length - 8)}${end}`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,14 +4,40 @@
 export type ApiConfigType = 'official' | 'third-party' | 'community';
 
 /**
+ * API Key 信息
+ */
+export interface IApiKey {
+  /** Key ID（唯一标识） */
+  id: string;
+
+  /** API Key */
+  apiKey: string;
+
+  /** 别名（可选） */
+  alias?: string;
+
+  /** 是否为默认 Key */
+  isDefault?: boolean;
+
+  /** 创建时间 */
+  createdAt: string;
+
+  /** 最后使用时间 */
+  lastUsed?: string;
+}
+
+/**
  * API 配置接口
  */
 export interface IApiConfig {
   /** 配置名称（唯一标识） */
   name: string;
 
-  /** API Key */
-  apiKey: string;
+  /** API Keys 列表 */
+  keys: IApiKey[];
+
+  /** 当前活动的 Key ID */
+  activeKeyId?: string;
 
   /** API Base URL */
   baseUrl: string;
@@ -27,6 +53,10 @@ export interface IApiConfig {
 
   /** 更新时间 */
   updatedAt: string;
+
+  // 以下字段用于向后兼容，不推荐使用
+  /** @deprecated 使用 keys 代替 */
+  apiKey?: string;
 }
 
 /**

--- a/src/utils/config-helpers.ts
+++ b/src/utils/config-helpers.ts
@@ -1,0 +1,95 @@
+import { IApiConfig, IApiKey } from '../types';
+import { randomBytes } from 'crypto';
+
+/**
+ * 生成唯一的 Key ID
+ */
+export function generateKeyId(): string {
+  return randomBytes(8).toString('hex');
+}
+
+/**
+ * 迁移旧格式配置到新格式
+ * @param config 可能是旧格式的配置
+ * @returns 新格式的配置
+ */
+export function migrateConfig(config: any): IApiConfig {
+  // 如果已经是新格式（有 keys 数组），直接返回
+  if (config.keys && Array.isArray(config.keys)) {
+    return config as IApiConfig;
+  }
+
+  // 旧格式：有 apiKey 字段
+  if (config.apiKey) {
+    const keyId = generateKeyId();
+    const apiKey: IApiKey = {
+      id: keyId,
+      apiKey: config.apiKey,
+      isDefault: true,
+      createdAt: config.createdAt || new Date().toISOString()
+    };
+
+    const migratedConfig: IApiConfig = {
+      ...config,
+      keys: [apiKey],
+      activeKeyId: keyId
+    };
+
+    // 删除旧的 apiKey 字段
+    delete (migratedConfig as any).apiKey;
+
+    return migratedConfig;
+  }
+
+  // 没有 apiKey 也没有 keys，返回带空 keys 数组的配置
+  return {
+    ...config,
+    keys: []
+  } as IApiConfig;
+}
+
+/**
+ * 获取配置的活动 Key
+ * @param config 配置对象
+ * @returns 活动的 Key，如果没有则返回 undefined
+ */
+export function getActiveKey(config: IApiConfig): IApiKey | undefined {
+  if (config.keys.length === 0) {
+    return undefined;
+  }
+
+  // 如果指定了 activeKeyId，返回对应的 key
+  if (config.activeKeyId) {
+    const key = config.keys.find(k => k.id === config.activeKeyId);
+    if (key) return key;
+  }
+
+  // 否则返回默认 key
+  const defaultKey = config.keys.find((k: IApiKey) => k.isDefault);
+  if (defaultKey) return defaultKey;
+
+  // 如果没有默认 key，返回第一个
+  return config.keys[0];
+}
+
+/**
+ * 获取配置的活动 API Key 字符串
+ * @param config 配置对象
+ * @returns API Key 字符串
+ */
+export function getActiveApiKey(config: IApiConfig): string | undefined {
+  const activeKey = getActiveKey(config);
+  return activeKey?.apiKey;
+}
+
+/**
+ * 脱敏显示 API Key
+ * @param apiKey API Key
+ * @returns 脱敏后的 API Key
+ */
+export function maskApiKey(apiKey: string): string {
+  if (apiKey.length <= 8) {
+    return '***';
+  }
+  return `${apiKey.substring(0, 4)}...${apiKey.substring(apiKey.length - 4)}`;
+}


### PR DESCRIPTION
## 概述

实现了 Issue #15 提出的多 API Key 管理功能，允许为同一个配置维护多个 API Key，方便在不同账号或额度耗尽时快速切换。

## 主要功能

### 1. 多 Key 管理系统
- ✅ 支持为单个配置维护多个 API Key
- ✅ Key 支持别名，方便识别（如 "主账号"、"备用账号"等）
- ✅ 自动跟踪活动 Key 和最后使用时间
- ✅ 防止删除最后一个 Key，确保配置始终可用

### 2. 新增 key 管理命令

#### `ccm key add [config-name]`
为配置添加新的 API Key
- 支持命令行参数：`-k` 指定 API Key，`-a` 指定别名
- 不带参数时交互式输入

#### `ccm key list [config-name]`
列出配置的所有 API Keys
- 显示别名、脱敏后的 Key、状态（活动/默认）、最后使用时间
- 清晰标识当前活动的 Key

#### `ccm key switch [config-name] [key-id-or-alias]`
切换配置的活动 Key
- 支持通过 Key ID 或别名切换
- 切换后询问是否立即应用到 Claude Code
- 自动更新最后使用时间

#### `ccm key remove [config-name] [key-id-or-alias]`
删除配置中的 API Key
- 有二次确认，防止误删
- 不允许删除最后一个 Key
- 删除活动 Key 时自动切换到其他 Key

### 3. 完整的交互式体验
- 所有命令参数均为可选
- **带参数时**：直接执行，无交互
- **不带参数时**：友好的交互式菜单选择
- 提供清晰的提示和错误信息

### 4. 数据迁移与兼容性
- ✅ 自动检测旧格式配置并迁移到新格式
- ✅ 保持完全向后兼容，现有配置无缝升级
- ✅ 迁移过程对用户透明，无需手动操作

### 5. 其他改进
- 更新 `ccm show` 命令，显示 Keys 数量和活动 Key
- 提取公共辅助函数到 `src/utils/config-helpers.ts`
- 改进错误处理和用户提示

## 技术实现

### 数据结构变更
```typescript
// 新增 IApiKey 接口
export interface IApiKey {
  id: string;              // 唯一标识
  apiKey: string;          // API Key
  alias?: string;          // 别名（可选）
  isDefault?: boolean;     // 是否为默认 Key
  createdAt: string;       // 创建时间
  lastUsed?: string;       // 最后使用时间
}

// IApiConfig 从单个 apiKey 改为 keys 数组
export interface IApiConfig {
  name: string;
  keys: IApiKey[];         // Key 数组
  activeKeyId?: string;    // 当前活动的 Key ID
  baseUrl: string;
  type: ApiConfigType;
  description?: string;
  createdAt: string;
  updatedAt: string;
}
```

### 文件变更
- 新增 `src/commands/key.ts` - Key 管理命令
- 新增 `src/utils/config-helpers.ts` - 辅助函数
- 修改 `src/types.ts` - 数据结构定义
- 修改 `src/config-manager.ts` - 核心管理逻辑
- 修改 `src/cli.ts` - CLI 命令集成
- 修改 `src/commands/list.ts` - 显示优化

## 测试

- ✅ 构建成功，无 TypeScript 类型错误
- ✅ 旧配置自动迁移测试通过
- ✅ 带参数命令测试通过
- ✅ 命令帮助信息显示正确

## 使用示例

```bash
# 为配置添加新的 Key（交互式）
ccm key add

# 为指定配置添加 Key（带参数）
ccm key add anyrouter -k sk-xxx -a "备用账号"

# 列出配置的所有 Keys（交互式）
ccm key list

# 列出指定配置的 Keys
ccm key list anyrouter

# 切换活动 Key（交互式）
ccm key switch

# 切换到指定 Key
ccm key switch anyrouter my-key-alias

# 删除 Key（交互式）
ccm key remove

# 删除指定 Key
ccm key remove anyrouter my-key-alias
```

## 截图

<details>
<summary>查看命令帮助</summary>

```bash
$ ccm key --help
Usage: ccm key [options] [command]

管理配置的 API Keys

Options:
  -h, --help                                 display help for command

Commands:
  add [options] [config-name]                为配置添加新的 API Key
  list|ls [config-name]                      列出配置的所有 API Keys
  switch [config-name] [key-id-or-alias]     切换配置的活动 API Key
  remove|rm [config-name] [key-id-or-alias]  删除配置的 API Key
  help [command]                             display help for command
```
</details>

Closes #15